### PR TITLE
Disable light visualization

### DIFF
--- a/harmonic_demo/Harmonic Mascot/model.sdf
+++ b/harmonic_demo/Harmonic Mascot/model.sdf
@@ -59,6 +59,7 @@
           <falloff>0.8</falloff>
         </spot>
         <cast_shadows>false</cast_shadows>
+        <visualize>false</visualize>
       </light>
     </link>
   </model>

--- a/harmonic_demo/harmonic.sdf
+++ b/harmonic_demo/harmonic.sdf
@@ -288,6 +288,7 @@
       <diffuse>0.8 0.8 0.8 1</diffuse>
       <specular>0.01 0.01 0.01 1</specular>
       <intensity>2</intensity>
+      <visualize>false</visualize>
     </light>
     <light type="point" name="point_light">
       <pose>0.73 0.09 8.77 0 0 0</pose>
@@ -300,6 +301,7 @@
         <quadratic>0.01</quadratic>
       </attenuation>
       <cast_shadows>true</cast_shadows>
+      <visualize>false</visualize>
     </light>
     <light type="point" name="point_light_01">
       <pose>3.482 -4.28 8.87 0 0 0</pose>
@@ -312,6 +314,7 @@
         <quadratic>0.001</quadratic>
       </attenuation>
       <cast_shadows>false</cast_shadows>
+      <visualize>false</visualize>
     </light>
     <light type="point" name="point_light_02">
       <pose>0.13 0.46 11.60 0 0 0</pose>
@@ -324,6 +327,7 @@
         <quadratic>0.001</quadratic>
       </attenuation>
       <cast_shadows>false</cast_shadows>
+      <visualize>false</visualize>
     </light>
     <light type="point" name="point_light_03">
       <pose>4.27 -1.27 11.21 0 0 0</pose>
@@ -336,6 +340,7 @@
         <quadratic>0.001</quadratic>
       </attenuation>
       <cast_shadows>false</cast_shadows>
+      <visualize>false</visualize>
     </light>
     <light type="point" name="point_light_04">
       <pose>-0.31 -3.78 8.61 0 0 0</pose>
@@ -348,6 +353,7 @@
         <quadratic>0.001</quadratic>
       </attenuation>
       <cast_shadows>false</cast_shadows>
+      <visualize>false</visualize>
     </light>
     <include>
       <name>Lake House</name>


### PR DESCRIPTION
Disable light visualization (the green lines) by default for the demo. The visualizations can be enabled through the `Lights` GUI plugin if needed.