### PR TITLE
mimic demo: reverse rack axis direction

### DIFF
--- a/harmonic_demo/harmonic_mimic_mechanisms.sdf
+++ b/harmonic_demo/harmonic_mimic_mechanisms.sdf
@@ -914,7 +914,7 @@
         <parent>base</parent>
         <child>rack</child>
         <axis>
-          <xyz>0 1.0 0</xyz>
+          <xyz>0 -1.0 0</xyz>
           <mimic joint="upper_joint">
             <multiplier>0.105</multiplier>
           </mimic>


### PR DESCRIPTION
The rack-and-pinion demo had a reversed axis direction. This fixes it


https://github.com/gazebosim/harmonic_demo/assets/3650755/a3992788-18e8-4976-bfe3-10aa8f1ef188

