### PR TITLE
Added mass demo with two spheres

### DIFF
--- a/harmonic_demo/Spheres/model.config
+++ b/harmonic_demo/Spheres/model.config
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<model>
+  <name>Spheres</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+
+</model>

--- a/harmonic_demo/Spheres/model.sdf
+++ b/harmonic_demo/Spheres/model.sdf
@@ -1,0 +1,79 @@
+<?xml version='1.0' ?>
+<sdf version="1.6">
+  <model name="spheres">
+       <link name="sphere_no_added_mass">
+        <inertial>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="sphere_no_added_mass_collision">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+        </collision>
+
+        <visual name="sphere_no_added_mass_visual">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <specular>0 1 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name="sphere_with_added_mass">
+      <pose relative_to="sphere_no_added_mass">0 -1 0 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+          <mass>1.0</mass>
+          <fluid_added_mass>
+            <xx>261.666</xx>
+            <yy>261.666</yy>
+            <zz>261.666</zz>
+          </fluid_added_mass>
+        </inertial>
+        <collision name="sphere_with_added_mass_collision">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+        </collision>
+
+        <visual name="sphere_with_added_mass_visual">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <specular>0 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+  </model>
+</sdf>

--- a/harmonic_demo/fluid_added_mass.sdf
+++ b/harmonic_demo/fluid_added_mass.sdf
@@ -1,0 +1,120 @@
+<?xml version="1.0" ?>
+<!--
+
+Demo of fluid added mass SDF parameter.
+
+-->
+<sdf version="1.6">
+  <world name="fluid_added_mass">
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <gravity>0 0 -9.8</gravity>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+   <include>
+      <name>Water</name>
+      <uri>Coast Waves 2</uri>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+
+    <model name="sphere_no_added_mass">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+        </collision>
+
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <specular>0 1 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="sphere_in_water">
+      <pose>0 1.5 0.5 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+          <mass>1.0</mass>
+          <fluid_added_mass>
+            <xx>261.666</xx>
+            <yy>261.666</yy>
+            <zz>261.666</zz>
+          </fluid_added_mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+        </collision>
+
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <specular>0 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/harmonic_demo/harmonic.sdf
+++ b/harmonic_demo/harmonic.sdf
@@ -285,6 +285,7 @@
           <density>1</density>
         </density_change>
       </graded_buoyancy>
+      <enable>Tethys</enable>
     </plugin>
     <plugin
       filename="gz-sim-dvl-system"

--- a/harmonic_demo/harmonic.sdf
+++ b/harmonic_demo/harmonic.sdf
@@ -375,6 +375,11 @@
       <pose>0 0 0 0 0 0</pose>
     </include>
     <include>
+      <name>Spheres</name>
+      <pose>-35 65 0 0 0 0</pose>
+      <uri>Spheres</uri>
+    </include>
+    <include>
       <name>Terrain</name>
       <uri>Terrain</uri>
     </include>

--- a/harmonic_demo/harmonic.sdf
+++ b/harmonic_demo/harmonic.sdf
@@ -380,6 +380,26 @@
       <pose>-35 65 0 0 0 0</pose>
       <uri>Spheres</uri>
     </include>
+    <model name="spheres_platform">
+      <static>true</static>
+      <pose>-35 64.5 -1.6 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>5 5 0.5</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>5 5 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
     <include>
       <name>Terrain</name>
       <uri>Terrain</uri>


### PR DESCRIPTION
# 🎉 New feature

## Summary
Added mass functionality in action with two spheres, one having added mass (which increases the force required to accelerate a submerged body) and one without.

## Test it
Go to the spheres model and one sphere with added mass will sink slower than the other sphere with only normal mass.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
